### PR TITLE
Merge prefix and route attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Installs and configures [ExaBGP](https://github.com/Exa-Networks/exabgp), the sw
 * Ubuntu 12.04
 * Ubuntu 13.04
 * Ubuntu 14.04
+* CentOS 6
+* CentOS 7
 
 ## Dependencies
 

--- a/attributes/exabgp.rb
+++ b/attributes/exabgp.rb
@@ -5,11 +5,11 @@ default[:exabgp][:community] = [0]
 default[:exabgp][:hold_time] = 20
 
 default[:exabgp][:ipv4][:neighbor] = '127.0.0.1'
-default[:exabgp][:ipv4][:anycast] = '127.0.0.1'
+default[:exabgp][:ipv4][:anycast] = '127.0.0.1/32'
 default[:exabgp][:ipv4][:enable_static_route] = true
 
 default[:exabgp][:ipv6][:neighbor] = nil
-default[:exabgp][:ipv6][:anycast] = '::1'
+default[:exabgp][:ipv6][:anycast] = '::1/128'
 
 default[:exabgp][:source_version] = 'master'
 default[:exabgp][:bin_path] = '/usr/local/bin/exabgp'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,12 +39,12 @@ template 'exabgp: config' do
              hold_time: node[:exabgp][:hold_time],
              neighbor_ipv4: node[:exabgp][:ipv4][:neighbor],
              local_address_ipv4: node.ipaddress,
-             route_ipv4: node[:exabgp][:ipv4][:anycast].gsub(/\d+$/, '0'),
+             route_ipv4: node[:exabgp][:ipv4][:anycast],
              enable_ipv4_static_route: node[:exabgp][:ipv4][:enable_static_route],
 
              neighbor_ipv6: node[:exabgp][:ipv6][:neighbor],
              local_address_ipv6: node[:ipv6address],
-             route_ipv6: node[:exabgp][:ipv6][:anycast].gsub(/\d+$/, ''),
+             route_ipv6: node[:exabgp][:ipv6][:anycast],
 
              local_as: node[:exabgp][:local_as],
              peer_as: node[:exabgp][:peer_as],

--- a/templates/default/exabgp.conf.erb
+++ b/templates/default/exabgp.conf.erb
@@ -15,7 +15,7 @@ neighbor <%= @neighbor_ipv4 %> {
   }
 
   static {
-    route <%= @route_ipv4 %>/24 {
+    route <%= @route_ipv4 %> {
       next-hop <%= @local_address_ipv4 %>;
       community [<%= @community %>];
       watchdog route_0;
@@ -37,7 +37,7 @@ neighbor <%= @neighbor_ipv6 %> {
   }
 
   static {
-    route <%= @route_ipv6 %>/48 {
+    route <%= @route_ipv6 %> {
       next-hop <%= @local_address_ipv6 %>;
       community [<%= @community %>];
     }


### PR DESCRIPTION
Merge prefix and route attributes, because it's absolutely not necessary to have both. It's more understandable to have one attribute like `route/prefix` instead of two. 
