### PR TITLE
Merge route and prefix attributes

### DIFF
--- a/attributes/exabgp.rb
+++ b/attributes/exabgp.rb
@@ -6,11 +6,11 @@ default[:exabgp][:hold_time] = 20
 default[:exabgp][:local_preference] = nil
 
 default[:exabgp][:ipv4][:neighbor] = '127.0.0.1'
-default[:exabgp][:ipv4][:anycast] = '127.0.0.1'
+default[:exabgp][:ipv4][:anycast] = '127.0.0.1/32'
 default[:exabgp][:ipv4][:enable_static_route] = true
 
 default[:exabgp][:ipv6][:neighbor] = nil
-default[:exabgp][:ipv6][:anycast] = '::1'
+default[:exabgp][:ipv6][:anycast] = '::1/128'
 
 default[:exabgp][:source_version] = 'master'
 default[:exabgp][:bin_path] = '/usr/local/bin/exabgp'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,7 +45,7 @@ template 'exabgp: config' do
 
              neighbor_ipv6: node[:exabgp][:ipv6][:neighbor],
              local_address_ipv6: node[:ipv6address],
-             route_ipv6: node[:exabgp][:ipv6][:anycast].gsub(/\d+$/, ''),
+             route_ipv6: node[:exabgp][:ipv6][:anycast],
 
              local_as: node[:exabgp][:local_as],
              peer_as: node[:exabgp][:peer_as],

--- a/templates/default/exabgp.conf.erb
+++ b/templates/default/exabgp.conf.erb
@@ -15,7 +15,7 @@ neighbor <%= @neighbor_ipv4 %> {
   }
 
   static {
-    route <%= @route_ipv4 %>/24 {
+    route <%= @route_ipv4 %> {
       next-hop <%= @local_address_ipv4 %>;
       <% if @local_preference %>
       local-preference <%= @local_preference %>;
@@ -40,7 +40,7 @@ neighbor <%= @neighbor_ipv6 %> {
   }
 
   static {
-    route <%= @route_ipv6 %>/48 {
+    route <%= @route_ipv6 %> {
       next-hop <%= @local_address_ipv6 %>;
       <% if @local_preference %>
       local-preference <%= @local_preference %>;


### PR DESCRIPTION
Merge prefix and route attributes, because it's absolutely not necessary to have both. It's more understandable to have one attribute like route/prefix instead of two. 
