### PR TITLE
Add local-preference attribute to have not ECMP if needed

### DIFF
--- a/attributes/exabgp.rb
+++ b/attributes/exabgp.rb
@@ -3,6 +3,7 @@ default[:exabgp][:peer_as] = 12345
 default[:exabgp][:community] = [0]
 
 default[:exabgp][:hold_time] = 20
+default[:exabgp][:local_preference] = nil
 
 default[:exabgp][:ipv4][:neighbor] = '127.0.0.1'
 default[:exabgp][:ipv4][:anycast] = '127.0.0.1'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,6 +39,7 @@ template 'exabgp: config' do
              hold_time: node[:exabgp][:hold_time],
              neighbor_ipv4: node[:exabgp][:ipv4][:neighbor],
              local_address_ipv4: node.ipaddress,
+             local_preference: node[:exabgp][:local_preference],
              route_ipv4: node[:exabgp][:ipv4][:anycast].gsub(/\d+$/, '0'),
              enable_ipv4_static_route: node[:exabgp][:ipv4][:enable_static_route],
 

--- a/templates/default/exabgp.conf.erb
+++ b/templates/default/exabgp.conf.erb
@@ -17,6 +17,9 @@ neighbor <%= @neighbor_ipv4 %> {
   static {
     route <%= @route_ipv4 %>/24 {
       next-hop <%= @local_address_ipv4 %>;
+      <% if @local_preference %>
+      local-preference <%= @local_preference %>;
+      <% end %>
       community [<%= @community %>];
       watchdog route_0;
     }
@@ -39,6 +42,9 @@ neighbor <%= @neighbor_ipv6 %> {
   static {
     route <%= @route_ipv6 %>/48 {
       next-hop <%= @local_address_ipv6 %>;
+      <% if @local_preference %>
+      local-preference <%= @local_preference %>;
+      <% end %>
       community [<%= @community %>];
     }
   }


### PR DESCRIPTION
Add local-preference attribute. This is needed in cases when unequal balancing is needed, like active/passive.
