### PR TITLE
Add multiple anycast IP announcement

### DIFF
--- a/attributes/exabgp.rb
+++ b/attributes/exabgp.rb
@@ -6,11 +6,11 @@ default['exabgp']['hold_time'] = 20
 default['exabgp']['local_preference'] = nil
 
 default['exabgp']['ipv4']['neighbor'] = '127.0.0.1'
-default['exabgp']['ipv4']['anycast'] = '127.0.0.1/32'
+default['exabgp']['ipv4']['anycast'] = ['127.0.0.1/32', '127.0.0.2/32']
 default['exabgp']['ipv4']['enable_static_route'] = true
 
 default['exabgp']['ipv6']['neighbor'] = nil
-default['exabgp']['ipv6']['anycast'] = '::1/128'
+default['exabgp']['ipv6']['anycast'] = ['::1/128']
 
 default['exabgp']['source_version'] = 'master'
 default['exabgp']['bin_path'] = '/usr/local/bin/exabgp'

--- a/libraries/route.rb
+++ b/libraries/route.rb
@@ -1,0 +1,4 @@
+def route(version = 'ipv4')
+  anycast_ip = node['exabgp'][version]['anycast']
+  return anycast_ip.kind_of?(String) ? [anycast_ip] : anycast_ip
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,12 +40,12 @@ template 'exabgp: config' do
              neighbor_ipv4: node['exabgp']['ipv4']['neighbor'],
              local_address_ipv4: node['ipaddress'],
              local_preference: node['exabgp']['local_preference'],
-             route_ipv4: node['exabgp']['ipv4']['anycast'],
+             route_ipv4: route('ipv4'),
              enable_ipv4_static_route: node['exabgp']['ipv4']['enable_static_route'],
 
              neighbor_ipv6: node['exabgp']['ipv6']['neighbor'],
              local_address_ipv6: node['ipv6address'],
-             route_ipv6: node['exabgp']['ipv6']['anycast'],
+             route_ipv6: route('ipv6'),
 
              local_as: node['exabgp']['local_as'],
              peer_as: node['exabgp']['peer_as'],

--- a/templates/default/exabgp.conf.erb
+++ b/templates/default/exabgp.conf.erb
@@ -15,7 +15,8 @@ neighbor <%= @neighbor_ipv4 %> {
   }
 
   static {
-    route <%= @route_ipv4 %> {
+    <% @route_ipv4.each do |ip| %>
+    route <%= ip %> {
       next-hop <%= @local_address_ipv4 %>;
       <% if @local_preference %>
       local-preference <%= @local_preference %>;
@@ -23,6 +24,7 @@ neighbor <%= @neighbor_ipv4 %> {
       community [<%= @community %>];
       watchdog route_0;
     }
+    <% end %>
   }
   <% end -%>
 }
@@ -40,13 +42,15 @@ neighbor <%= @neighbor_ipv6 %> {
   }
 
   static {
-    route <%= @route_ipv6 %> {
+    <% @route_ipv6.each do |ip| %>
+    route <%= ip %> {
       next-hop <%= @local_address_ipv6 %>;
       <% if @local_preference %>
       local-preference <%= @local_preference %>;
       <% end %>
       community [<%= @community %>];
     }
+    <% end %>
   }
 }
 <% end %>


### PR DESCRIPTION
Add multiple anycast IP announcement. This is useful when needed to announce more than one IP to upstream. For example from different subnets.
