### PR TITLE
Add version pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ the swiss-army knife of networking.
 
 | Attribute | Description | Default Value |
 | --- | --- | --- |
+| `node['exabgp']['package_version']` | Version of the python package to install | `3.4.19` |
 | `node['exabgp']['bin_path']` | Location of the ExaBGP binary, only set on source installations | `/usr/sec/exabgp/sbin/exabgp` |
 | `node['exabgp']['config_path']` | Location of the ExaBGP configuration file, only set when a resource with instance set to false is configured | `/etc/exabgp/exabgp.conf` |
 | `node['exabgp']['source_url']` | URL to the git repository for source installtions | `https://github.com/Exa-Networks/exabgp.git` |
@@ -39,7 +40,6 @@ resource of choice.
 #### Actions
 
 * `:install` – Install and configure ExaBGP. *(default)*
-* `:remove` – Remove ExaBGP and configuration file.
 
 #### Parameters
 
@@ -49,6 +49,8 @@ resource of choice.
                 is for backward compatibility with the older version of this
                 cookbook where you may be running an install from
                 `/etc/exabgp`.
+* `package_version` – Which version of the python package to install, defaults
+                      to the `node['exabgp']['package_version'] attribute.
 * `cookbook` – Which cookbook to look for the exabgp.conf.erb template
 * `variables` – Pass template variables in much like a template resource
 * `install_type` – Supports both :package and :source installations. Defaults

--- a/attributes/exabgp.rb
+++ b/attributes/exabgp.rb
@@ -1,2 +1,3 @@
+default['exabgp']['version'] = '3.4.19'
 default['exabgp']['source_url'] = 'https://github.com/Exa-Networks/exabgp.git'
 default['exabgp']['source_version'] = 'master'

--- a/attributes/exabgp.rb
+++ b/attributes/exabgp.rb
@@ -1,3 +1,3 @@
-default['exabgp']['version'] = '3.4.19'
+default['exabgp']['package_version'] = '3.4.19'
 default['exabgp']['source_url'] = 'https://github.com/Exa-Networks/exabgp.git'
 default['exabgp']['source_version'] = 'master'

--- a/libraries/exabgp.rb
+++ b/libraries/exabgp.rb
@@ -9,7 +9,7 @@ module ExabgpCookbook
     property :variables, kind_of: Hash
 
     action :install do
-      case install_type
+      case new_resource.install_type
       when :package
         include_recipe 'poise-python'
 

--- a/libraries/exabgp.rb
+++ b/libraries/exabgp.rb
@@ -4,6 +4,7 @@ module ExabgpCookbook
 
     property :instance, kind_of: [String, FalseClass], name_property: true
     property :install_type, kind_of: Symbol, default: :package
+    property :package_version, kind_of: String, default: lazy { node['exabgp']['package_version'] }
     property :cookbook, kind_of: String
     property :variables, kind_of: Hash
 
@@ -14,6 +15,7 @@ module ExabgpCookbook
 
         python_package 'exabgp' do
           action :install
+          version new_resource.package_version
         end
       when :source
         package 'git-core'


### PR DESCRIPTION
This is a minor version change to add in package_version as an option to the resource. It's a less invasive approach to re-writing the entire resource setup to work with 4.0 of ExaBGP.

It also adds in a small bugfix to avoid a namespace collision with the install type where we weren't using new_resource when we should have been.