### PR TITLE
Do not update exabgp resource every chef run

### DIFF
--- a/resources/exabgp.rb
+++ b/resources/exabgp.rb
@@ -9,10 +9,7 @@ property :variables, Hash
 include ExabgpCookbook::Helpers
 
 action :install do
-  log 'deprecation_warning' do
-    message '***EXABGP COOKBOOK DEPRECATION NOTICE!*** The exabgp resource will be replaced by exabgp_install and exabgp_config in a future release. It will also only support Chef 13.10+ so please pin your version now to avoid issues in the very near future! See README for migration details.'
-    level :warn
-  end
+  ::Chef::Log.warn '***EXABGP COOKBOOK DEPRECATION NOTICE!*** The exabgp resource will be replaced by exabgp_install and exabgp_config in a future release. It will also only support Chef 13.10+ so please pin your version now to avoid issues in the very near future! See README for migration details.'
 
   case new_resource.install_type
   when :package


### PR DESCRIPTION
Use `::Chef::Log.warn` instead of the log resource, otherwise the parent exabgp resource is always updated.
This is bad when notifications or subscriptions are setup on the exabgp resource :)